### PR TITLE
scripts/livekit.sh: reduce the size of the target image agressively

### DIFF
--- a/scripts/livekit.sh
+++ b/scripts/livekit.sh
@@ -1,3 +1,20 @@
+FONT_WEIGHTS_TO_STRIP=(
+	'*Condensed*'
+	'*Black*'
+	'*SemiBold*'
+	'*emiLight*'
+	'*ExtraLight*'
+	'*ExtraBold*'
+	'*ExtraBlack*'
+	'*Medium*'
+	'*Light*'
+)
+
+MANUALS_TO_STRIP=(
+	"/usr/share/man/man3"
+	"/usr/share/man/man3l"
+)
+
 echo "Customising Plymouth theme ..."
 sed -e 's|semaphore|livekit|g' \
     -i /etc/plymouth/plymouthd.conf
@@ -72,3 +89,14 @@ systemctl mask hibernation.target
 echo "Disabling open file handle limit ..."
 sed -e '/^fs.file-max/d' \
     -i /etc/sysctl.d/00-kernel.conf
+
+echo "Removing unnecessary fonts..."
+for weight in ${FONT_WEIGHTS_TO_STRIP[@]} ; do
+	find /usr/share/fonts -type f -not -type l -iname $weight -delete
+done
+
+echo "Removing unnecessary manual pages..."
+for mandir in ${MANUALS_TO_STRIP[@]} ; do
+	echo "Removing $mandir"
+	rm -r $mandir
+done


### PR DESCRIPTION
This PR modifies the LiveKit script to remove unnexessary font weights and manual pages, which take up to half a gig of space:

![image](https://github.com/AOSC-Dev/aosc-mklive/assets/29174191/5733d6ca-2614-445a-b131-7df75f1c9ab4)

The script can be found at https://paste.aosc.io/paste/UuoZ2f4JWSEUU7O~4aWmZQ.

The resulting image is about 0.5GiB smaller compared to unprocessed one:
```
$ ls -lh aosc-os_livekit_20230729_amd64.iso /mirror/mirror/anthon/aosc-os/os-amd64/livekit/aosc-os_livekit_20230711_amd64.iso
-rw-rw-r-- 1 root kvm  3.4G Jul11日 16:26 /mirror/mirror/anthon/aosc-os/os-amd64/livekit/aosc-os_livekit_20230711_amd64.iso
-rw-r--r-- 1 root root 3.0G Jul29日 17:37 aosc-os_livekit_20230729_amd64.iso
```
