### PR TITLE
More serial quirks

### DIFF
--- a/boot/grub/init.cfg
+++ b/boot/grub/init.cfg
@@ -76,21 +76,22 @@ if [ "x$retro" = "x0" ] ; then
 		# Assume the serial terminal supports UTF-8.
 		terminfo -u $serial
 		terminal_input --append console
+		set append="--append"
 		if [ "x$isconsole" = "x1" ] ; then
 			terminal_output --append console
-		else
-			terminal_output --append gfxterm
 		fi
 		set show_serial=1
 	else
 		terminal_input console
-		if [ "x$isconsole" = "x1" ] ; then
-			terminal_output console
-		elif ! terminal_output gfxterm ; then
-			set no_video=1
-			terminal_output console
-			terminfo -u console
-		fi
+	fi
+	if [ "x$isconsole" = "x1" ] ; then
+		terminal_output console
+	# If we have serial, and we are not using the console, we want both serial and gfxterm.
+	# Otherwise, use either console or gfxterm.
+	elif ! terminal_output $append gfxterm ; then
+		set no_video=1
+		terminal_output $append console
+		terminfo -u console
 	fi
 	if [ "x$no_video" = "x1" ] ; then
 		set nogui=1

--- a/boot/grub/init.cfg
+++ b/boot/grub/init.cfg
@@ -35,7 +35,10 @@ set has_serial=0
 # Flag to determine if the menu entries with serial consle should be
 # displayed.
 set show_serial=0
-
+# Flag to indicate whether the system has a broken EFI serial console.
+set broken_efi_serial=0
+# Flag to indicate whether the system has a proper video output.
+set no_video=0
 # Show the splash screen and suppress the boot log by default.
 set quiet_arg="quiet splash"
 
@@ -50,7 +53,7 @@ if [ "x$retro" = "x0" ] ; then
 	if [ "x$detect_serial" = "x0" ] ; then
 		echo "Skipping initializing the serial console."
 		echo "Menu entries with serial console will be left enabled."
-	elif [ "x$grub_platform" = "xefi" ] ; then
+	elif [ "x$grub_platform" = "xefi" -a "x$broken_efi_serial" != "x1" ] ; then
 		# Prefer the serial reported by EFI.
 		set serial=serial_efi0
 		if ! terminal_output $serial ; then
@@ -83,14 +86,22 @@ if [ "x$retro" = "x0" ] ; then
 		terminal_input console
 		if [ "x$isconsole" = "x1" ] ; then
 			terminal_output console
-		else
-			terminal_output gfxterm
+		elif ! terminal_output gfxterm ; then
+			set no_video=1
+			terminal_output console
+			terminfo -u console
 		fi
 	fi
-	loadfont /boot/grub/fonts/unicode.pf2
-	echo "show_serial = ${show_serial}"
-	set nogui=0
+	if [ "x$no_video" = "x1" ] ; then
+		set nogui=1
+		set isconsole=1
+		set show_serial=1
+	else
+		loadfont /boot/grub/fonts/unicode.pf2
+		set nogui=0
+	fi
 	set nocli=0
+	echo "show_serial = ${show_serial}"
 	set menu_color_normal=white/black
 	set menu_color_highlight=black/white
 	set cli_title=$"Install AOSC OS (Command-line Only)"

--- a/boot/grub/quirks.cfg
+++ b/boot/grub/quirks.cfg
@@ -80,6 +80,15 @@ set noserialchk_platforms="
 	mips64el-efi
 "
 
+# Serial console provided by EFI environment may be broken on some systems.
+# GRUB has serial_efi* specifically, to use the serial console provided by
+# the firmware. However, if GRUB attempts to use EFI serial console on
+# these broken EFI serial consoles, the system may freeze.
+# Skip serial initialization on such systems.
+set broken_efi_serial_list="
+	HUAWEIPGU-WBY0
+"
+
 for platform in $nomemchk_platforms ; do
 	if [ "x${grub_cpu}-${grub_platform}" = "x$platform" ] ; then
 		set memcheck=0
@@ -112,6 +121,13 @@ for platform in $noserialchk_platforms ; do
 	if [ "x${grub_cpu}-${grub_platform}" = "x$platform" ] ; then
 		set detect_serial=0
 		set show_serial=1
+		break
+	fi
+done
+
+for model in $broken_efi_serial_list ; do
+	if [ "x$system_model" = "x$model" ]; then
+		set broken_efi_serial=1
 		break
 	fi
 done

--- a/boot/grub/serial-args.cfg
+++ b/boot/grub/serial-args.cfg
@@ -6,7 +6,7 @@ if [ "x${grub_cpu}-${grub_platform}" = "xmips64el-efi" ] ; then
 	set serial_console_arg="console=ttyS0,115200 console=tty0 keep_bootcon"
 elif [ "x${grub_cpu}-${grub_platform}" = "xpowerpc-ieee1275" ] ; then
 	set serial_console_arg="console=ttyS0,115200 console=hvc0 console=tty0"
-elif [ "x${grub_cpu}-${grub_platform}" = "xaarch64-efi" ] ; then
+elif [ "x${grub_cpu}-${grub_platform}" = "xarm64-efi" ] ; then
 	set serial_console_arg="console=ttyS0,115200 console=ttyAMA0,115200 console=tty0"
 else
 	set serial_console_arg="console=ttyS0,115200 console=tty0"

--- a/gen-installer.sh
+++ b/gen-installer.sh
@@ -178,7 +178,9 @@ bootstrap_base() {
 	_dir="${WORKDIR}"/base
 	info "Bootstrapping base tarball ..."
 	aoscbootstrap \
-		${BRANCH:-stable} $_dir ${REPO} \
+		--branch ${BRANCH:-stable} \
+		--target $WORKDIR/livekit \
+		--mirror ${REPO:-https://repo.aosc.io/debs} \
 		--config "$AOSCBOOTSTRAP/config/aosc-mainline.toml" \
 		-x \
 		$TOPIC_OPT \

--- a/gen-livekit.sh
+++ b/gen-livekit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 # New LiveKit generator.
 # This "new" LiveKit will use our dracut loader to load the LiveKit.
 
@@ -46,7 +46,9 @@ info "Invoking aoscbootstrap ..."
 if [[ "${ARCH}" = "loongarch64" ]]; then
 	echo "Generating LiveKit distribution (loongarch64) ..."
 	aoscbootstrap \
-		${BRANCH:-stable} $WORKDIR/livekit ${REPO:-https://repo.aosc.io/debs} \
+		--branch ${BRANCH:-stable} \
+		--target $WORKDIR/livekit \
+		--mirror ${REPO:-https://repo.aosc.io/debs} \
 		--config /usr/share/aoscbootstrap/config/aosc-mainline.toml \
 		-x --force \
 		$TOPIC_OPTS \
@@ -60,7 +62,9 @@ if [[ "${ARCH}" = "loongarch64" ]]; then
 elif [[ "${RETRO}" != "1" ]]; then
 	echo "Generating LiveKit distribution ..."
 	aoscbootstrap \
-		${BRANCH:-stable} ${WORKDIR}/livekit ${REPO:-https://repo.aosc.io/debs} \
+		--branch ${BRANCH:-stable} \
+		--target $WORKDIR/livekit \
+		--mirror ${REPO:-https://repo.aosc.io/debs} \
 		--config /usr/share/aoscbootstrap/config/aosc-mainline.toml \
 		-x --force \
 		--arch ${ARCH:-$(dpkg --print-architecture)} \
@@ -73,7 +77,9 @@ elif [[ "${RETRO}" != "1" ]]; then
 else
 	echo "Generating Retro LiveKit distribution ..."
 	aoscbootstrap \
-		${BRANCH:-stable} ${WORKDIR}/livekit ${REPO:-https://repo.aosc.io/debs-retro} \
+		--branch ${BRANCH:-stable} \
+		--target $WORKDIR/livekit \
+		--mirror ${REPO:-https://repo.aosc.io/debs} \
 		--config /usr/share/aoscbootstrap/config/aosc-retro.toml \
 		-x --force \
 		--arch ${ARCH:-$(dpkg --print-architecture)} \


### PR DESCRIPTION
* New `broken_efi_serial` quirk to mark systems with broken EFI serial console implementation
* Make sure serial console is enabled along with gfxterm/console
* Fix `console=` kernel arg for aarch64

Tested good on a real headless Huawei W510, and QEMU Q35 virtual machine with both serial and graphics.